### PR TITLE
Add two field types

### DIFF
--- a/src/main/java/com/khubla/pdxreader/db/DBTableField.java
+++ b/src/main/java/com/khubla/pdxreader/db/DBTableField.java
@@ -115,6 +115,12 @@ public class DBTableField {
                   throw new Exception("Invalid field length '" + length + "' for type '" + type + "'");
                }
                break;
+            case 04:
+               fieldType = FieldType.I;
+               if (length != 4) {
+                  throw new Exception("Invalid field length '" + length + "' for type '" + type + "'");
+               }
+               break;
             case 05:
                fieldType = FieldType.$;
                if (length != 8) {
@@ -132,6 +138,12 @@ public class DBTableField {
                break;
             case 0Xd:
                fieldType = FieldType.B;
+               break;
+            case 0X15:
+               fieldType = FieldType.TS;
+               if (length != 8) {
+                  throw new Exception("Invalid field length '" + length + "' for type '" + type + "'");
+               }
                break;
             case 22:
                fieldType = FieldType.Auto;

--- a/src/main/java/com/khubla/pdxreader/db/DBTableValue.java
+++ b/src/main/java/com/khubla/pdxreader/db/DBTableValue.java
@@ -66,6 +66,11 @@ public class DBTableValue {
                final long s = ByteBuffer.wrap(data).order(ByteOrder.LITTLE_ENDIAN).getShort();
                value = Long.toString(s);
                break;
+            case I:
+               data[0] = (byte) (data[0] & 0x7f); // handle unsigned integers
+               final long i = ByteBuffer.wrap(data).order(ByteOrder.BIG_ENDIAN).getInt();
+               value = Long.toString(i);
+               break;
             case $:
                final double dollars = ByteBuffer.wrap(data).order(ByteOrder.BIG_ENDIAN).getDouble();
                value = Double.toString(dollars);
@@ -78,6 +83,19 @@ public class DBTableValue {
                break;
             case B:
                value = StringUtil.ByteArrayToString(data);
+               break;
+            case TS:
+               // milliseconds since Jan 1, 1 AD, convert to UTC time
+               data[0] = (byte) (data[0] & 0x7f); // handle unsigned number
+               double dt = ByteBuffer.wrap(data).order(ByteOrder.BIG_ENDIAN).getDouble();
+               long dateTime = (long) dt;
+               if (dateTime == 0) {
+                  value = null;
+               } else {
+                  dateTime -= 86400000; // millis in 1 day
+                  dateTime -= 62135607600000l; // millis from 01.01.1970
+                  value = Long.toString(dateTime);
+               }
                break;
             case Auto:
                final short auto = ByteBuffer.wrap(data).order(ByteOrder.LITTLE_ENDIAN).getShort();


### PR DESCRIPTION
Add handling for integer and timestamp types 
- in my case they were unsigned and have to unsign them
- datetime in paradox comes with mills since January 1, 1 - have to convert to UTC time

Not sure that my case is universal but can be checked on other db-files.