### PR TITLE
removes trim from StringUtil.readString

### DIFF
--- a/src/main/java/com/khubla/pdxreader/db/DBTableHeader.java
+++ b/src/main/java/com/khubla/pdxreader/db/DBTableHeader.java
@@ -520,11 +520,11 @@ public class DBTableHeader {
          if (fileVersionID == 0x0c) {
             final byte[] fn = new byte[261];
             littleEndianDataInputStream.read(fn);
-            embeddedFilename = StringUtil.readString(fn);
+            embeddedFilename = StringUtil.readString(fn).trim();
          } else {
             final byte[] fn = new byte[79];
             littleEndianDataInputStream.read(fn);
-            embeddedFilename = StringUtil.readString(fn);
+            embeddedFilename = StringUtil.readString(fn).trim();
          }
          /*
           * now read the field names

--- a/src/main/java/com/khubla/pdxreader/util/StringUtil.java
+++ b/src/main/java/com/khubla/pdxreader/util/StringUtil.java
@@ -39,7 +39,7 @@ public class StringUtil {
       final StringBuilder stringBuilder = new StringBuilder();
       final CharBuffer charBuffer = Charset.forName(encoding).decode(ByteBuffer.wrap(data));
       stringBuilder.append(charBuffer);
-      return stringBuilder.toString().trim();
+      return stringBuilder.toString();
    }
 
    /**
@@ -55,10 +55,15 @@ public class StringUtil {
    public static String readString(LittleEndianDataInputStream littleEndianDataInputStream, String encoding) throws IOException {
       final ByteBuffer byteBuffer = ByteBuffer.allocate(MAX_STRING);
       Byte c = littleEndianDataInputStream.readByte();
+      int len = 0;
       while (c != 0) {
          byteBuffer.put(c);
          c = littleEndianDataInputStream.readByte();
+         len++;
       }
-      return readString(byteBuffer.array(), encoding);
+      byteBuffer.position(0);
+      byte[] data = new byte[len];
+      byteBuffer.get(data,0,len);
+      return readString(data, encoding);
    }
 }


### PR DESCRIPTION
Resolves #21 

in StringUtil.java removed trim() from readString.  fixed the null terminated readString so that it doesn't rely on trim()

added trim() to embeddedFilename readString in DBTableHeader.java